### PR TITLE
#167 add utf-8 encoding when open file

### DIFF
--- a/api/backend/info_api.py
+++ b/api/backend/info_api.py
@@ -9,17 +9,17 @@ def info_text():
     :rtype: json dict
     """
     info_dict = {}
-    with open("./src/info_text/info_box_build.txt", "r") as f:
+    with open("./src/info_text/info_box_build.txt", "r", encoding='UTF-8') as f:
         q = f.readlines()
         lines = [i.rstrip("\n") for i in q]
         info_dict["build"] = lines
-    with open("./src/info_text/info_box_assay.txt", "r") as f:
+    with open("./src/info_text/info_box_assay.txt", "r", encoding='UTF-8') as f:
         q = f.readlines()
         lines = [i.rstrip("\n") for i in q]
         info_dict["assay"] = lines
-    with open("./src/info_text/info_box_analysis.txt", "r") as f:
+    with open("./src/info_text/info_box_analysis.txt", "r", encoding='UTF-8') as f:
         q = f.readlines()
         lines = [i.rstrip("\n") for i in q]
         info_dict["analysis"] = lines
-    
+
     return jsonify({"info_dict": info_dict})


### PR DESCRIPTION
Fix the gbk encoding problem by adding 'encoding=utf-8' when open files to the info_api.py file.