### PR TITLE
changed the README to specify the port as 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ This assumes the conda environment has been created and necessary packages insta
 ```
 conda activate dd_game
 export FLASK_APP=api/service
-flask run
+flask run -p 8000
 ```


### PR DESCRIPTION
Solves issue with CORS policy on macs by changing the port to 8000 in the README so everyone uses 8000 as it works on both mac and windows.
Run with frontend branch "analysis_actions_test" - in this branch the scripts have been changed to say localhost 8000 instead of 5000. If it is already merged you can test on main. 